### PR TITLE
Set old subject line as variable to use in reply

### DIFF
--- a/source/mail-filters.rst
+++ b/source/mail-filters.rst
@@ -85,8 +85,11 @@ Vacation auto reply
 
 .. code-block:: cfg
 
-    require ["vacation"];
-
+    require ["variables", "vacation"];
+    # Store old Subject line so it can be used in vacation message
+    if header :matches "Subject" "*" {
+        set "subjwas" "${1}";
+    }
     vacation
       # Reply at most once a week to a same sender
       :days 7


### PR DESCRIPTION
The old subject line was not catched as a variable, added require variables and set subjwas as the old messages subject.